### PR TITLE
Add Composer Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name"       : "devinsays/customizer-library",
+    "description": "Customizer Library - A helpful library for working with the WordPress customizer.",
+    "keywords"   : ["wordpress", "customizer"],
+    "homepage"   : "https://github.com/devinsays/customizer-library",
+    "license"    : "GPL-2.0+",
+    "authors"    : [
+        {
+            "name"    : "Devin Price",
+            "email"   : "devin@wptheming.com",
+            "homepage": "http://wptheming.com"
+        }
+    ],
+    "support"    : {
+        "issues": "https://github.com/devinsays/customizer-library/issues",
+        "source": "https://github.com/devinsays/customizer-library"
+    },
+    "autoload" : {
+        "files" : ["customizer-library.php"]
+    }
+}


### PR DESCRIPTION
This should be all you need to add support for composer. Once you merge it in, just head over to https://packagist.org/ and register it as a package. I'm not 100% sure if this should contain a classmap or not. Might want to check with @Rarst. This should take care of #8 
