### PR TITLE
Adding Range control & Description parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The Customizer Library currently supports these options:
 * Upload
 * Image
 * Color
+* Range
 * Textarea
 * Select (Typography)
 
@@ -142,6 +143,24 @@ $options['example-color'] = array(
 	'section' => $section,
 	'type'    => 'color',
 	'default' => $color // hex
+);
+~~~
+
+### Range
+
+~~~php
+$options['example-range'] = array(
+	'id' => 'example-range',
+	'label'   => __( 'Example Range', 'demo' ),
+	'section' => $section,
+	'type'    => 'range',
+	'default' => '',
+    'input_attrs' => array(
+        'min'   => 100,
+        'max'   => 3000,
+        'step'  => 100
+    ),
+
 );
 ~~~
 

--- a/extensions/interface.php
+++ b/extensions/interface.php
@@ -94,7 +94,8 @@ function customizer_library_register( $wp_customize ) {
 								'section'           => $option['section'],
 								'sanitize_callback' => $option['sanitize_callback'],
 								'priority'          => $option['priority'],
-								'active_callback'	=> $option['active_callback']
+								'active_callback'	=> $option['active_callback'],
+								'description'	    => $option['description']
 							)
 						)
 					);
@@ -111,7 +112,8 @@ function customizer_library_register( $wp_customize ) {
 								'section'           => $option['section'],
 								'sanitize_callback' => $option['sanitize_callback'],
 								'priority'          => $option['priority'],
-								'active_callback'	=> $option['active_callback']
+								'active_callback'	=> $option['active_callback'],
+								'description'	    => $option['description']
 							)
 						)
 					);
@@ -188,7 +190,8 @@ function customizer_library_add_setting( $option, $wp_customize )  {
 		'theme_supports' => null,
 		'transport' => null,
 		'sanitize_callback' => 'wp_kses_post',
-		'sanitize_js_callback' => null
+		'sanitize_js_callback' => null,
+		'description' => null
 	);
 
 	// Settings defaults
@@ -202,7 +205,8 @@ function customizer_library_add_setting( $option, $wp_customize )  {
 			'theme_supports' => $settings['theme_supports'],
 			'transport' => $settings['transport'],
 			'sanitize_callback' => $settings['sanitize_callback'],
-			'sanitize_js_callback' => $settings['sanitize_js_callback']
+			'sanitize_js_callback' => $settings['sanitize_js_callback'],
+			'description' => $settings['description']
 		)
 	);
 

--- a/extensions/interface.php
+++ b/extensions/interface.php
@@ -51,6 +51,11 @@ function customizer_library_register( $wp_customize ) {
 				$option['active_callback'] = '';
 			}
 
+			// Set blank description if one isn't set
+			if ( ! isset( $option['description'] ) ) {
+				$option['description'] = '';
+			}
+
 			// Add the setting
 			customizer_library_add_setting( $option, $wp_customize );
 

--- a/extensions/interface.php
+++ b/extensions/interface.php
@@ -26,6 +26,15 @@ function customizer_library_register( $wp_customize ) {
 		return;
 	}
 
+    // Add the panel
+    $wp_customize->add_panel( 'theme_options', array(
+        'priority' => 10,
+        'capability' => 'edit_theme_options',
+        'theme_supports' => '',
+        'title' => __( 'Theme Options', 'demo' ),
+        'description' => __( 'Theme specific options.', 'demo' ),
+    ) );
+
 	// Add the sections
 	if ( isset( $options['sections'] ) ) {
 		customizer_library_add_sections( $options['sections'], $wp_customize );

--- a/extensions/interface.php
+++ b/extensions/interface.php
@@ -75,6 +75,7 @@ function customizer_library_register( $wp_customize ) {
 				case 'select':
 				case 'radio':
 				case 'checkbox':
+				case 'range':
 
 					$wp_customize->add_control(
 						$option['id'], $option

--- a/extensions/interface.php
+++ b/extensions/interface.php
@@ -26,15 +26,6 @@ function customizer_library_register( $wp_customize ) {
 		return;
 	}
 
-    // Add the panel
-    $wp_customize->add_panel( 'theme_options', array(
-        'priority' => 10,
-        'capability' => 'edit_theme_options',
-        'theme_supports' => '',
-        'title' => __( 'Theme Options', 'demo' ),
-        'description' => __( 'Theme specific options.', 'demo' ),
-    ) );
-
 	// Add the sections
 	if ( isset( $options['sections'] ) ) {
 		customizer_library_add_sections( $options['sections'], $wp_customize );


### PR DESCRIPTION
I've added the range control along with additional support for the description parameter introduced in 4.0. This should help with the suggestion made in https://github.com/devinsays/customizer-library/issues/20

Reference: New Built-in Customizer Control Parameters
https://make.wordpress.org/core/2014/07/08/customizer-improvements-in-4-0/