### PR TITLE
* Use esc_url_raw() when sanitizing for the database

### DIFF
--- a/extensions/sanitization.php
+++ b/extensions/sanitization.php
@@ -80,7 +80,7 @@ function customizer_library_sanitize_file_url( $url ) {
 
 	$filetype = wp_check_filetype( $url );
 	if ( $filetype["ext"] ) {
-		$output = esc_url( $url );
+		$output = esc_url_raw( $url );
 	}
 
 	return $output;


### PR DESCRIPTION
esc_url() is used for displaying a URL, but [esc_url_raw()](http://codex.wordpress.org/Function_Reference/esc_url_raw) is preferred when saving to the database.

(@justintadlock pointed this out to me in a code review.)